### PR TITLE
OSV-23765 - CVE - Bumped-up Jackson to 2.18.6 to address CVE-2020-9548

### DIFF
--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -33,7 +33,7 @@
   
   <properties>
   	<neo4j.driver.version>4.1.1</neo4j.driver.version>
-  	<jackson.version>2.16.1</jackson.version>
+  	<jackson.version>2.18.6</jackson.version>
     <interpreter.name>neo4j</interpreter.name>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <gson.version>2.8.9</gson.version>
     <gson-extras.version>0.2.2</gson-extras.version>
     <org-json.version>20240205</org-json.version>
-    <jackson.version>2.18.3</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <jetty.version>11.0.28</jetty.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
@@ -179,7 +179,7 @@
     <plugin.os.version>1.4.1.Final</plugin.os.version>
     <jinjava.version>2.8.3</jinjava.version>
     <guava.version>32.0.1-jre</guava.version>
-    <jackson.version>2.16.1</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <testcontainers.version>1.19.0</testcontainers.version>
     <netty.codec.http2.version>4.1.133.Final</netty.codec.http2.version>
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -39,7 +39,7 @@
     <org.reflections.version>0.9.8</org.reflections.version>
     <xml.apis.version>1.4.01</xml.apis.version>
     <commons.vfs2.version>2.10.0</commons.vfs2.version>
-    <jackson.annocations.version>2.19.1</jackson.annocations.version>
+    <jackson.annocations.version>2.18.6</jackson.annocations.version>
     <eclipse.jgit.version>6.10.0.202406032230-r</eclipse.jgit.version>
     <eirslett.version>1.6</eirslett.version>
   </properties>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-23765, OSV-23766, OSV-23767, OSV-23768, OSV-23769, OSV-23770, OSV-23771, OSV-23772, OSV-23773, OSV-23774, OSV-23775, OSV-23776, OSV-23777, OSV-23778, OSV-23779, OSV-23780, OSV-23781, OSV-23782, OSV-23783, OSV-23784, OSV-23785, OSV-23786, OSV-23787, OSV-23788, OSV-23789, OSV-23790, OSV-23791, OSV-23792, OSV-23793, OSV-23794, OSV-23795, OSV-23796, OSV-23797, OSV-23798, OSV-23799, OSV-23800, OSV-23801, OSV-23802, OSV-23803, OSV-23804, OSV-23805, OSV-23806, OSV-23807, OSV-23808, OSV-23809, OSV-23810, OSV-23811, OSV-23812, OSV-23813, OSV-23814, OSV-23815, OSV-23816, OSV-23817, OSV-23861, OSV-23862, OSV-23863, OSV-23864, OSV-23881, OSV-23882, OSV-23883, OSV-23884, OSV-23885, OSV-23886, OSV-23897