### PR TITLE
OSV-23825 - CVE - Bumped-up commons-configuration2 to 2.15.0 to address CVE-2026-45205

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <commons.compress.version>1.26.1</commons.compress.version>
     <commons.lang3.version>3.14.0</commons.lang3.version>
     <commons.text.version>1.10.0</commons.text.version>
-    <commons.configuration2.version>2.10.1</commons.configuration2.version>
+    <commons.configuration2.version>2.15.0</commons.configuration2.version>
     <commons.exec.version>1.3</commons.exec.version>
     <commons.codec.version>1.16.1</commons.codec.version>
     <commons.io.version>2.15.1</commons.io.version>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-configuration2 → 2.15.0
- Tickets: OSV-23825
- Files: pom.xml