### PR TITLE
OSV-23872 - CVE - Bumped-up mina-core to 2.0.28 to address CVE-2026-41409/CVE-2026-41635

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -40,7 +40,7 @@
     <jna.version>4.1.0</jna.version>
     <nimbus.version>9.37.2</nimbus.version>
     <kerberos.version>2.0.0.AM26</kerberos.version>
-    <mina.version>2.0.27</mina.version>
+    <mina.version>2.0.28</mina.version>
 
     <!--test library versions-->
     <selenium.java.version>4.11.0</selenium.java.version>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: mina-core → 2.0.28
- Tickets: OSV-23872, OSV-23873
- Files: zeppelin-server/pom.xml