### PR TITLE
OSV-23829 - CVE - Bumped-up BouncyCastle to 1.84 to address CVE-2024-29857/CVE-2024-30171/CVE-2024-34447/CVE-2025-8916/CVE-2026-5588

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.cli.version>1.4</commons.cli.version>
     <shiro.version>1.13.0</shiro.version>
-    <bouncycastle.version>1.70</bouncycastle.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <maven.version>3.6.3</maven.version>
     <dropwizard.version>4.2.29</dropwizard.version>
     <micrometer.version>1.14.2</micrometer.version>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: BouncyCastle → 1.84
- Tickets: OSV-23829, OSV-23830, OSV-23842, OSV-23843, OSV-23845
- Files: pom.xml