### PR TITLE
OSV-23846 - CVE - Bumped-up commons-vfs2 to 2.10.0 to address CVE-2025-27553/CVE-2025-30474

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -38,7 +38,7 @@
     <lucene.version>8.11.4</lucene.version>
     <org.reflections.version>0.9.8</org.reflections.version>
     <xml.apis.version>1.4.01</xml.apis.version>
-    <commons.vfs2.version>2.6.0</commons.vfs2.version>
+    <commons.vfs2.version>2.10.0</commons.vfs2.version>
     <jackson.annocations.version>2.19.1</jackson.annocations.version>
     <eclipse.jgit.version>6.10.0.202406032230-r</eclipse.jgit.version>
     <eirslett.version>1.6</eirslett.version>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-vfs2 → 2.10.0
- Tickets: OSV-23846, OSV-23847
- Files: zeppelin-zengine/pom.xml