### PR TITLE
OSV-23748 - CVE - Bumped-up Netty to 4.1.133.Final to address CVE-2025-55163/CVE-2025-58056/CVE-2025-59419/CVE-2025-67735/CVE-2026-33870/CVE-2026-33871/CVE-2026-41417/CVE-2026-42578/CVE-2026-42579/CVE-2026-42580/CVE-2026-42581/CVE-2026-42583/CVE-2026-42584/CVE-2026-42585/CVE-2026-42586/CVE-2026-42587/CVE-2026-44248

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <guava.version>32.0.1-jre</guava.version>
     <jackson.version>2.16.1</jackson.version>
     <testcontainers.version>1.19.0</testcontainers.version>
-    <netty.codec.http2.version>4.1.132.Final</netty.codec.http2.version>
+    <netty.codec.http2.version>4.1.133.Final</netty.codec.http2.version>
 
     <MaxMetaspace>512m</MaxMetaspace>
 


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Netty → 4.1.133.Final
- Tickets: OSV-23748, OSV-23834, OSV-23848, OSV-23849, OSV-23850, OSV-23851, OSV-23852, OSV-23853, OSV-23854, OSV-23855, OSV-23856, OSV-23857, OSV-23866, OSV-23871, OSV-23874, OSV-23878, OSV-23879, OSV-23880
- Files: pom.xml