### PR TITLE
OSV-23826 - CVE - Bumped-up nimbus-jose-jwt to 10.0.2 to address CVE-2025-53864

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -38,7 +38,7 @@
     <javax.ws.rsapi.version>2.1</javax.ws.rsapi.version>
     <libpam4j.version>1.11</libpam4j.version>
     <jna.version>4.1.0</jna.version>
-    <nimbus.version>9.37.2</nimbus.version>
+    <nimbus.version>10.0.2</nimbus.version>
     <kerberos.version>2.0.0.AM26</kerberos.version>
     <mina.version>2.0.27</mina.version>
 


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: nimbus-jose-jwt → 10.0.2
- Tickets: OSV-23826
- Files: zeppelin-server/pom.xml