### PR TITLE
OSV-23827 - CVE - Bumped-up okhttp to 4.9.2 to address CVE-2021-0341/CVE-2023-0833

### DIFF
--- a/influxdb/pom.xml
+++ b/influxdb/pom.xml
@@ -36,7 +36,7 @@
         <interpreter.name>influxdb</interpreter.name>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <influxdb.client.version>1.7.0</influxdb.client.version>
-        <dependency.okhttp3.version>3.13.1</dependency.okhttp3.version>
+        <dependency.okhttp3.version>4.9.2</dependency.okhttp3.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: okhttp → 4.9.2
- Tickets: OSV-23827, OSV-23828
- Files: influxdb/pom.xml, pom.xml