### PR TITLE
OSV-23764 - CVE - Bumped-up okio to 3.4.0 to address CVE-2023-3635

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,12 @@
 
   <dependencyManagement>
     <dependencies>
+<dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>3.4.0</version>
+      </dependency>
+
 
       <dependency>
         <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: okio → 3.4.0
- Tickets: OSV-23764
- Files: pom.xml