### PR TITLE
OSV-23762 - CVE - Bumped-up OpenTelemetry to 1.62.0 to address CVE-2026-45292

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,11 @@
   <dependencyManagement>
     <dependencies>
 <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-api</artifactId>
+        <version>1.62.0</version>
+      </dependency>
+<dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
         <version>3.9.0</version>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: OpenTelemetry → 1.62.0
- Tickets: OSV-23762
- Files: pom.xml