### PR TITLE
OSV-23867 - CVE - Bumped-up jinjava to 2.8.3 to address CVE-2025-59340/CVE-2026-25526

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <plugin.scm.version>1.11.2</plugin.scm.version>
     <plugin.source.version>3.2.1</plugin.source.version>
     <plugin.os.version>1.4.1.Final</plugin.os.version>
-    <jinjava.version>2.6.0</jinjava.version>
+    <jinjava.version>2.8.3</jinjava.version>
     <guava.version>32.0.1-jre</guava.version>
     <jackson.version>2.16.1</jackson.version>
     <testcontainers.version>1.19.0</testcontainers.version>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: jinjava → 2.8.3
- Tickets: OSV-23867, OSV-23868
- Files: pom.xml