### PR TITLE
OSV-23841 - CVE - Bumped-up jsoup to 1.15.3 to address CVE-2022-36033

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 
     <quartz.scheduler.version>2.3.2</quartz.scheduler.version>
     <jettison.version>1.5.4</jettison.version>
-    <jsoup.version>1.14.2</jsoup.version>
+    <jsoup.version>1.15.3</jsoup.version>
     <protobuf.version>3.25.5</protobuf.version>
     <grpc.version>1.55.1</grpc.version>
     <google.errorprone.version>2.14.0</google.errorprone.version>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: jsoup → 1.15.3
- Tickets: OSV-23841
- Files: pom.xml