### PR TITLE
OSV-23761 - CVE - Bumped-up commons-net to 3.9.0 to address CVE-2021-37533

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,10 +187,17 @@
 
     <!-- to be able to exclude some tests using command line -->
     <tests.to.exclude/>
+        <commons.net.version>3.9.0</commons.net.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+<dependency>
+        <groupId>commons-net</groupId>
+        <artifactId>commons-net</artifactId>
+        <version>3.9.0</version>
+      </dependency>
+
 <dependency>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-net → 3.9.0
- Tickets: OSV-23761
- Files: pom.xml, pom.xml