### PR TITLE
OSV-23822 - CVE - Bumped-up plexus-utils to 3.6.1 to address CVE-2025-67030

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,13 @@
 
   <dependencyManagement>
     <dependencies>
+
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
+
       <!-- markdown -->
       <dependency>
         <groupId>com.vladsch.flexmark</groupId>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: plexus-utils → 3.6.1
- Tickets: OSV-23822
- Files: pom.xml