### PR TITLE
OSV-23818 - CVE - Bumped-up Jetty to 11.0.28 to address CVE-2025-11143/CVE-2026-2332/CVE-2026-5795

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <gson-extras.version>0.2.2</gson-extras.version>
     <org-json.version>20240205</org-json.version>
     <jackson.version>2.18.3</jackson.version>
-    <jetty.version>11.0.24</jetty.version>
+    <jetty.version>11.0.28</jetty.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.14</httpcomponents.client.version>


### PR DESCRIPTION
- Component: zeppelin (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Jetty → 11.0.28
- Tickets: OSV-23818, OSV-23819, OSV-23820
- Files: pom.xml