### PR TITLE
ODP-7387 : Revert "OSV-23829 - CVE - Bumped-up BouncyCastle to 1.84 to address CVE-2024-29857/CVE-2024-30171/CVE-2024-34447/CVE-2025-8916/CVE-2026-5588 (#50)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <gson-extras.version>0.2.2</gson-extras.version>
     <org-json.version>20240205</org-json.version>
     <jackson.version>2.18.6</jackson.version>
-    <jetty.version>11.0.28</jetty.version>
+    <jetty.version>11.0.26</jetty.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.14</httpcomponents.client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.cli.version>1.4</commons.cli.version>
     <shiro.version>1.13.0</shiro.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.70</bouncycastle.version>
     <maven.version>3.6.3</maven.version>
     <dropwizard.version>4.2.29</dropwizard.version>
     <micrometer.version>1.14.2</micrometer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <plugin.scm.version>1.11.2</plugin.scm.version>
     <plugin.source.version>3.2.1</plugin.source.version>
     <plugin.os.version>1.4.1.Final</plugin.os.version>
-    <jinjava.version>2.8.3</jinjava.version>
+    <jinjava.version>2.7.6</jinjava.version>
     <guava.version>32.0.1-jre</guava.version>
     <jackson.version>2.18.6</jackson.version>
     <testcontainers.version>1.19.0</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.cli.version>1.4</commons.cli.version>
     <shiro.version>1.13.0</shiro.version>
-    <bouncycastle.version>1.70</bouncycastle.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <maven.version>3.6.3</maven.version>
     <dropwizard.version>4.2.29</dropwizard.version>
     <micrometer.version>1.14.2</micrometer.version>
@@ -414,7 +414,7 @@
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
 

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -190,7 +190,7 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
 
     <dependency>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -101,7 +101,7 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
…VE-2024-29857/CVE-2024-30171/CVE-2024-34447/CVE-2025-8916/CVE-2026-5588 (#50)"

This reverts commit 159136235196390b91b1054bc5aca8c40754b4ce.
